### PR TITLE
Add ANN recall and synthetic data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ TTL default **10 min**; after expiry client gets a fresh snapshot.
 | Python model env        | `cd model‑training && pip install -r requirements.txt` |
 | Benchmark 1 K QPS (WIP) | `scripts/bench.sh`                                     |
 
+### 7a · Synthetic Dataset
+Run `scripts/gen_mock_data.py --items 100000` to bootstrap a large DB with random embeddings.
+Use the generated `vibers_big.db` when testing ANN recall.
 *You may still use the included **Makefile** as a thin wrapper, but it's optional.*
 
 ---

--- a/internal/recall/ann.go
+++ b/internal/recall/ann.go
@@ -1,12 +1,33 @@
 package recall
 
 import (
+	"math"
+	"sort"
+
 	"github.com/Boomshakalak/VibeRS/internal/store"
 )
 
 // ANNRecaller handles approximate nearest neighbor recall strategies
 type ANNRecaller struct {
 	store *store.Service
+	items []store.Item
+	dim   int
+}
+
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i] * b[i])
+		na += float64(a[i] * a[i])
+		nb += float64(b[i] * b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
 }
 
 // NewANNRecaller creates a new ANN recall handler
@@ -14,13 +35,48 @@ func NewANNRecaller(storeService *store.Service) *ANNRecaller {
 	return &ANNRecaller{store: storeService}
 }
 
+// Build loads all embeddings from the store into memory
+func (ar *ANNRecaller) Build() error {
+	data, err := ar.store.GetAllItemEmbeddings()
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		ar.items = nil
+		return nil
+	}
+	ar.dim = len(data[0].Embedding)
+	ar.items = data
+	return nil
+}
+
 // VectorSimilarityRecall performs vector similarity search
 // SQL: ORDER BY Cosine(embedding, ?) DESC
 func (ar *ANNRecaller) VectorSimilarityRecall(queryEmbedding []float32, limit int) ([]store.Item, error) {
-	// TODO: Implement actual vector similarity search
-	// This would use the cosine similarity UDF in SQLite
-	// For now, return empty results as placeholder
-	return []store.Item{}, nil
+	if len(queryEmbedding) != ar.dim || len(ar.items) == 0 {
+		return []store.Item{}, nil
+	}
+	type pair struct {
+		id    int
+		score float64
+	}
+	scores := make([]pair, 0, len(ar.items))
+	for _, it := range ar.items {
+		if len(it.Embedding) != ar.dim {
+			continue
+		}
+		score := cosineSimilarity(it.Embedding, queryEmbedding)
+		scores = append(scores, pair{id: it.ItemID, score: score})
+	}
+	sort.Slice(scores, func(i, j int) bool { return scores[i].score > scores[j].score })
+	if len(scores) > limit {
+		scores = scores[:limit]
+	}
+	ids := make([]int, len(scores))
+	for i, p := range scores {
+		ids[i] = p.id
+	}
+	return ar.store.GetItemsByIDs(ids)
 }
 
 // SemanticSearchRecall performs semantic search using embeddings

--- a/internal/recall/ann_test.go
+++ b/internal/recall/ann_test.go
@@ -1,0 +1,55 @@
+package recall
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Boomshakalak/VibeRS/internal/store"
+)
+
+func TestANNBuildAndRecall(t *testing.T) {
+	dbPath := "test_ann.db"
+	os.Remove(dbPath)
+	db, err := store.InitDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		db.Close()
+		os.Remove(dbPath)
+	}()
+	schema := `CREATE TABLE items (
+               item_id INTEGER PRIMARY KEY,
+               title TEXT,
+               brand TEXT,
+               price_cents INTEGER,
+               discount REAL,
+               rating REAL,
+               stock INTEGER,
+               launched_at DATETIME,
+               click_7d INTEGER,
+               buy_7d INTEGER,
+               gmv_30d INTEGER,
+               embedding BLOB
+       );`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatal(err)
+	}
+	s := store.NewService(db)
+	emb := []byte{0, 0, 128, 63, 0, 0, 0, 64, 205, 204, 76, 63} // 1,2,0.95 in float32
+	_, err = db.Exec(`INSERT INTO items (item_id, title, brand, price_cents, discount, rating, stock, click_7d, buy_7d, gmv_30d, embedding) VALUES (1,'a','b',100,0,5,1,1,1,100, ?)`, emb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := NewANNRecaller(s)
+	if err := rec.Build(); err != nil {
+		t.Fatal(err)
+	}
+	items, err := rec.VectorSimilarityRecall([]float32{1, 2, 0.95}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+}

--- a/scripts/gen_mock_data.py
+++ b/scripts/gen_mock_data.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate a synthetic SQLite dataset with random items and embeddings.
+
+Usage:
+  python gen_mock_data.py --items 100000 --db data/vibers_big.db
+"""
+import argparse
+import random
+import sqlite3
+import struct
+from pathlib import Path
+
+BRANDS = [
+    "Gucci", "Louis Vuitton", "Chanel", "Hermes", "Prada",
+    "Saint Laurent", "Bottega Veneta", "Fendi", "Dior", "Balenciaga",
+]
+
+ADJECTIVES = [
+    "Classic", "Vintage", "Elegant", "Modern", "Chic",
+    "Luxury", "Sport", "Urban", "Retro", "Bold",
+]
+
+ITEMS = ["Bag", "Wallet", "Belt", "Shoe", "Backpack"]
+
+
+def random_embedding(dim: int) -> bytes:
+    values = [random.uniform(-1, 1) for _ in range(dim)]
+    return struct.pack('<%df' % dim, *values)
+
+
+def generate(db_path: Path, num_items: int, dim: int = 8) -> None:
+    if db_path.exists():
+        db_path.unlink()
+    conn = sqlite3.connect(str(db_path))
+    ddl = Path("data/ddl.sql").read_text()
+    conn.executescript(ddl)
+    for i in range(1, num_items + 1):
+        brand = random.choice(BRANDS)
+        title = f"{brand} {random.choice(ADJECTIVES)} {random.choice(ITEMS)} {i}"
+        price = random.randint(20000, 500000)
+        discount = round(random.uniform(0, 0.3), 2)
+        rating = round(random.uniform(3.5, 5.0), 1)
+        stock = random.randint(1, 50)
+        click = random.randint(0, 500)
+        buy = random.randint(0, 50)
+        gmv = price * buy
+        embedding = random_embedding(dim)
+        conn.execute(
+            "INSERT INTO items (item_id, title, brand, price_cents, discount, rating, stock, click_7d, buy_7d, gmv_30d, embedding) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (i, title, brand, price, discount, rating, stock, click, buy, gmv, embedding),
+        )
+    conn.commit()
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic dataset")
+    parser.add_argument("--items", type=int, default=100000, help="number of items")
+    parser.add_argument("--db", type=Path, default=Path("data/vibers_big.db"), help="output database path")
+    parser.add_argument("--dim", type=int, default=8, help="embedding dimension")
+    args = parser.parse_args()
+    args.db.parent.mkdir(parents=True, exist_ok=True)
+    generate(args.db, args.items, args.dim)
+    print(f"Generated {args.items} items in {args.db}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement simple in-memory ANN recaller
- add functions in store for embeddings and ID lookup
- register cosine similarity function with SQLite
- provide Python script to generate large mock dataset
- basic unit test for ANN recall
- document synthetic dataset script in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847e97fd9d48330b478ebff4fb5632d